### PR TITLE
Fix barcode digit order and improve performance

### DIFF
--- a/Main App/app/src/main/java/com/hsappdev/ahs/UI/profile/ProfileCardFragment.java
+++ b/Main App/app/src/main/java/com/hsappdev/ahs/UI/profile/ProfileCardFragment.java
@@ -40,6 +40,8 @@ public class ProfileCardFragment extends Fragment {
     private static final int RC_SIGN_IN = 8888;
     private Boolean gsSignedIn = false;
 
+    private BarcodeDrawable barcodeCanvas = new BarcodeDrawable();
+
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.profile_card_fragment, container, false);
@@ -149,7 +151,7 @@ public class ProfileCardFragment extends Fragment {
     }
 
     public void setUserId(String userId) {
-        BarcodeDrawable barcodeCanvas = new BarcodeDrawable(Integer.parseInt(userId));
+        barcodeCanvas.setUserId(Integer.parseInt(userId));
         barcodeImage.setImageDrawable(barcodeCanvas);
     }
 }

--- a/Main App/app/src/main/java/com/hsappdev/ahs/UI/profile/ProfileCardFragment.java
+++ b/Main App/app/src/main/java/com/hsappdev/ahs/UI/profile/ProfileCardFragment.java
@@ -3,6 +3,7 @@ package com.hsappdev.ahs.UI.profile;
 import android.content.Context;
 import android.content.Intent;
 import android.content.res.Resources;
+import android.net.Uri;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.LayoutInflater;
@@ -25,11 +26,12 @@ import com.hsappdev.ahs.R;
 import com.hsappdev.ahs.util.BarcodeDrawable;
 import com.hsappdev.ahs.util.ImageUtil;
 
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class ProfileCardFragment extends Fragment {
     private static final String TAG = "ProfileCardFragment";
-    private static final Pattern idOfEmail = Pattern.compile("^(\\d{5})@students\\.ausd\\.net$");
+    private static final Pattern userIdPattern = Pattern.compile("^(\\d{5})@students\\.ausd\\.net$");
 
     private TextView givenNameTextView;
     private TextView familyNameTextView;
@@ -40,7 +42,7 @@ public class ProfileCardFragment extends Fragment {
     private static final int RC_SIGN_IN = 8888;
     private Boolean gsSignedIn = false;
 
-    private BarcodeDrawable barcodeCanvas = new BarcodeDrawable();
+    private final BarcodeDrawable barcodeCanvas = new BarcodeDrawable();
 
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
@@ -66,17 +68,14 @@ public class ProfileCardFragment extends Fragment {
         gsSignedIn = account != null;
         if(gsSignedIn) setDetails(account);
 
-        view.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                if(gsSignedIn) {
-                    gsClient.signOut();
-                    gsSignedIn = false;
-                    setDetails(0);
-                } else {
-                    Intent signInIntent = gsClient.getSignInIntent();
-                    startActivityForResult(signInIntent, RC_SIGN_IN);
-                }
+        view.setOnClickListener(v -> {
+            if(gsSignedIn) {
+                gsClient.signOut();
+                gsSignedIn = false;
+                setDetails();
+            } else {
+                Intent signInIntent = gsClient.getSignInIntent();
+                startActivityForResult(signInIntent, RC_SIGN_IN);
             }
         });
 
@@ -100,7 +99,7 @@ public class ProfileCardFragment extends Fragment {
                 // The ApiException status code indicates the detailed failure reason.
                 // Please refer to the GoogleSignInStatusCodes class reference for more information.
                 Log.w(TAG, "signInResult:failed code=" + error.getStatusCode());
-                setDetails(0);
+                setDetails();
             }
         }
     }
@@ -115,20 +114,16 @@ public class ProfileCardFragment extends Fragment {
     public void setDetails(GoogleSignInAccount account){
         setGivenName(account.getGivenName());
         setFamilyName(account.getFamilyName());
-        try {
-            setPhotoUrl(account.getPhotoUrl().toString());
-        } catch (NullPointerException error) {
-            Log.d(TAG,"Profile photo does not exist.");
-        }
-        try {
-            setUserId(idOfEmail.matcher(account.getEmail()).group());
-        } catch (NullPointerException error) {
-            Log.d(TAG,"Email does not exist.");
-        } catch (IllegalStateException error) {
-            Log.d(TAG, "Email does not contain ID.");
-        }
+
+        Uri photoUrl = account.getPhotoUrl();
+        if(photoUrl != null) setPhotoUrl(photoUrl.toString());
+        else Log.d(TAG,"Profile photo does not exist.");
+
+        Matcher userIdMatcher = userIdPattern.matcher(account.getEmail());
+        if(userIdMatcher.matches()) setUserId(userIdMatcher.group(1));
+        else Log.d(TAG,"Email does not exist.");
     }
-    public void setDetails(int reset) {
+    public void setDetails() {
         Resources res = getResources();
         setDetails(
                 res.getString(R.string.profile_card_default_given_name),
@@ -152,6 +147,7 @@ public class ProfileCardFragment extends Fragment {
 
     public void setUserId(String userId) {
         barcodeCanvas.setUserId(Integer.parseInt(userId));
+        barcodeImage.setImageDrawable(null); // Clear canvas
         barcodeImage.setImageDrawable(barcodeCanvas);
     }
 }

--- a/Main App/app/src/main/java/com/hsappdev/ahs/util/BarcodeDrawable.java
+++ b/Main App/app/src/main/java/com/hsappdev/ahs/util/BarcodeDrawable.java
@@ -37,7 +37,7 @@ public class BarcodeDrawable extends Drawable {
         0b01_10_00_01_10_01,
     };
     private static final int viewportWidth = 208;
-    private static final int[] stripeWidths = new short[]{
+    private static final int[] stripeWidths = new int[]{
         2, // white space
         2, // narrow band
         5, // wide band
@@ -62,7 +62,7 @@ public class BarcodeDrawable extends Drawable {
         for(int i = userIdLength; i > 0; i--){
 
              // Extract unit digit as index
-            codeData[i] = codeData[userId % 10];
+            codeData[i] = codeDigits[userId % 10];
 
             // Remove unit digit
             userId /= 10;
@@ -87,18 +87,18 @@ public class BarcodeDrawable extends Drawable {
 
         for(int i = 0; i < codeDataLength; i++){
 
-            final short codeDigit = codeDigits[i];
+            final short codeDigit = codeData[i];
 
             for(int j = 0; j < codeDigitLength; j++){
 
                 // Extract stripe from codeDigit
-                final short stripeType = codeDigit >> 2*j & 0b11;
+                final int stripeType = codeDigit >> 2*j & 0b11;
 
                 // Get width of stripe
                 final float stripeWidth = unit * stripeWidths[stripeType];
 
                 // draw black line if stripe type is not space
-                if(type != 0) codePath.addRect(
+                if(stripeType != 0) codePath.addRect(
                         horizontalOffset,
                         0f,
                         horizontalOffset + stripeWidth,

--- a/Main App/app/src/main/java/com/hsappdev/ahs/util/BarcodeDrawable.java
+++ b/Main App/app/src/main/java/com/hsappdev/ahs/util/BarcodeDrawable.java
@@ -23,8 +23,8 @@ public class BarcodeDrawable extends Drawable {
 
     private static final int codeDataLength = userIdLength + 2;
     private static final int codeDigitLength = 6;
-    private static final int codeDelimiter = 0b01_00_01_10_10_01;
-    private static final int[] codeDigits = new int[]{
+    private static final short codeDelimiter = 0b01_00_01_10_10_01;
+    private static final short[] codeDigits = new short[]{
         0b01_01_00_10_10_01,
         0b10_01_00_01_01_10,
         0b01_10_00_01_01_10,
@@ -37,20 +37,27 @@ public class BarcodeDrawable extends Drawable {
         0b01_10_00_01_10_01,
     };
     private static final int viewportWidth = 208;
-    private static final int[] stripeWidths = new int[]{
+    private static final int[] stripeWidths = new short[]{
         2, // white space
         2, // narrow band
         5, // wide band
     };
 
-    private final int[] codeData = new int[codeDataLength];
+    private final short[] codeData = new short[codeDataLength];
     private final Path codePath = new Path();
 
-    public BarcodeDrawable(int userId) {
+    public BarcodeDrawable() {
 
-        // Create path data from id
         codeData[0] = codeData[codeDataLength - 1] = codeDelimiter;
 
+        // Set paint color
+        blackPaint.setColor(Color.BLACK);
+
+    }
+
+    public void setUserId(int userId) {
+
+        // Create path data from id
         // Go from least to most significant digit
         for(int i = userIdLength; i > 0; i--){
 
@@ -61,8 +68,6 @@ public class BarcodeDrawable extends Drawable {
             userId /= 10;
         }
 
-        // Set paint color
-        blackPaint.setColor(Color.BLACK);
     }
 
     @Override
@@ -78,14 +83,16 @@ public class BarcodeDrawable extends Drawable {
         // Draw from path data, with horizontal cursor offset set at 0
         float horizontalOffset = 0f;
 
+        final float gapWidth = 2 * unit;
+
         for(int i = 0; i < codeDataLength; i++){
 
-            final int codeDigit = codeDigits[i];
+            final short codeDigit = codeDigits[i];
 
             for(int j = 0; j < codeDigitLength; j++){
 
                 // Extract stripe from codeDigit
-                final int stripeType = codeDigit >> 2*j & 0b11;
+                final short stripeType = codeDigit >> 2*j & 0b11;
 
                 // Get width of stripe
                 final float stripeWidth = unit * stripeWidths[stripeType];
@@ -100,7 +107,6 @@ public class BarcodeDrawable extends Drawable {
                 );
 
                 // move cursor rightwards
-                final float gapWidth = 2 * unit;
                 horizontalOffset += stripeWidth + gapWidth;
 
             }

--- a/Main App/app/src/main/java/com/hsappdev/ahs/util/BarcodeDrawable.java
+++ b/Main App/app/src/main/java/com/hsappdev/ahs/util/BarcodeDrawable.java
@@ -73,6 +73,8 @@ public class BarcodeDrawable extends Drawable {
     @Override
     public void draw(Canvas canvas) {
 
+        codePath.reset();
+
         // Get the drawable's bounds
         final float width = getBounds().width();
         final float height = getBounds().height();
@@ -89,7 +91,7 @@ public class BarcodeDrawable extends Drawable {
 
             final short codeDigit = codeData[i];
 
-            for(int j = 0; j < codeDigitLength; j++){
+            for(int j = codeDigitLength-1; j >= 0; j--){
 
                 // Extract stripe from codeDigit
                 final int stripeType = codeDigit >> 2*j & 0b11;


### PR DESCRIPTION
Switch from strings to binary integer arrays to internally represent stripes, reuse the barcodeCanvas object, and fix the digit ordering.